### PR TITLE
Allow configuring what the Discord timestamp represents

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ const config = Object.assign(configJSON, {
 	},
 	discord: {
 		token: process.env.SCP_DISCORD_TOKEN,
+		showModificationDate: false,
 	},
 });
 

--- a/services/discord.js
+++ b/services/discord.js
@@ -34,10 +34,13 @@ module.exports = config => {
 					const iconColor = shortcut.icon.color.toString(16).slice(0, 6);
 					embed.setColor(iconColor);
 
-					// Make the footer
-					embed.setTimestamp(shortcut.creationDate);
+					// Make the footer either the creation or modification date based on the configuration
+					embed.setTimestamp(config.showModificationDate ? shortcut.modificationDate : shortcut.creationDate);
+					
+					// Add the bot's version to the footer
 					embed.setFooter(`ShortcutsPreview v${version}`);
 					
+					// Now we can send it
 					msg.channel.send("", embed);
 				});
 			}


### PR DESCRIPTION
Previously, the timestamp in the Discord service's embed showed the creation date for the shortcut. This pull request allows the `showModificationDate` config parameter to change it to show the modification date instead.