### PR TITLE
Include shortcuts' icons in the Discord preview

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ try {
 	process.stderr.write("The configuration for ShortcutsPreview is missing.\n");
 }
 
-const config = Object.assign(configJSON, {
+const config = Object.assign({
 	global: {
 		enabled: true,
 	},
@@ -23,8 +23,9 @@ const config = Object.assign(configJSON, {
 	},
 	discord: {
 		token: process.env.SCP_DISCORD_TOKEN,
+		previewShortcutIcon: true,
 	},
-});
+}, configJSON);
 
 function service(name) {
 	const serviceConfig = Object.assign(config.global, config[name]);

--- a/index.js
+++ b/index.js
@@ -1,7 +1,3 @@
-if (require('dotenv').config()) {
-	process.stderr.write("Using environment variables for configuration is deprecated. Please use config.json instead.\n");
-}
-
 try {
 	var configJSON = require("./config.json");
 } catch (error) {
@@ -15,14 +11,14 @@ const config = Object.assign({
 	},
 	reddit: {
 		credentials: {
-			clientId: process.env.SCP_REDDIT_ID,
-			clientSecret: process.env.SCP_REDDIT_SECRET,
-			username: process.env.SCP_REDDIT_USERNAME,
-			password: process.env.SCP_REDDIT_PASSWORD,
+			clientId: "",
+			clientSecret: "",
+			username: "",
+			password: "",
 		},
 	},
 	discord: {
-		token: process.env.SCP_DISCORD_TOKEN,
+		token: "",
 		previewShortcutIcon: true,
 	},
 }, configJSON);

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"discord.js": "^11.4.2",
 		"dotenv": "^6.0.0",
 		"markdown-escape": "^1.0.2",
-		"shortcuts.js": "^2.0.0",
+		"shortcuts.js": "^3.0.0",
 		"snoostorm": "0.0.5",
 		"snoowrap": "^1.15.2"
 	},

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
 	"homepage": "https://github.com/haykam821/ShortcutsPreview#readme",
 	"dependencies": {
 		"discord.js": "^11.4.2",
-		"dotenv": "^6.0.0",
 		"markdown-escape": "^1.0.2",
 		"shortcuts.js": "^3.0.0",
 		"snoostorm": "0.0.5",

--- a/services/discord.js
+++ b/services/discord.js
@@ -34,6 +34,12 @@ module.exports = config => {
 					const iconColor = shortcut.icon.color.toString(16).slice(0, 6);
 					embed.setColor(iconColor);
 
+					embed.attachFile({
+						attachment: shortcut.icon.downloadURL,
+						name: "icon.png",
+					});
+					embed.setThumbnail("attachment://icon.png");
+
 					// Make the footer
 					embed.setTimestamp(shortcut.creationDate);
 					embed.setFooter(`ShortcutsPreview v${version}`);

--- a/services/discord.js
+++ b/services/discord.js
@@ -17,9 +17,12 @@ module.exports = config => {
 			if (id) {
 				utils.getShortcutDetails(id).then(shortcut => {
 					const embed = new djs.RichEmbed();
-					
-					embed.setTitle("Shortcut: " + shortcut.name);
-					embed.setURL(shortcut.getLink());
+
+					embed.attachFile({
+						attachment: shortcut.icon.downloadURL,
+						name: "icon.png",
+					});
+					embed.setAuthor("Shortcut: " + shortcut.name, "attachment://icon.png", shortcut.getLink());
 					
 					const description = [];
 					
@@ -33,12 +36,6 @@ module.exports = config => {
 					// Get a normal hex color from the icon color for the embed color
 					const iconColor = shortcut.icon.color.toString(16).slice(0, 6);
 					embed.setColor(iconColor);
-
-					embed.attachFile({
-						attachment: shortcut.icon.downloadURL,
-						name: "icon.png",
-					});
-					embed.setThumbnail("attachment://icon.png");
 
 					// Make the footer
 					embed.setTimestamp(shortcut.creationDate);

--- a/services/discord.js
+++ b/services/discord.js
@@ -19,11 +19,13 @@ module.exports = config => {
 				getShortcutDetails(config.log, id).then(shortcut => {
 					const embed = new djs.RichEmbed();
 
-					embed.attachFile({
-						attachment: shortcut.icon.downloadURL,
-						name: "icon.png",
-					});
-					embed.setAuthor("Shortcut: " + shortcut.name, "attachment://icon.png", shortcut.getLink());
+					if (config.previewShortcutIcon) {
+						embed.attachFile({
+							attachment: shortcut.icon.downloadURL,
+							name: "icon.png",
+						});
+					}
+					embed.setAuthor("Shortcut: " + shortcut.name, config.previewShortcutIcon && "attachment://icon.png", shortcut.getLink());
 					
 					const description = [];
 					


### PR DESCRIPTION
This pull request adds an icon to the Discord preview, as seen below:

![Discord preview with icon](https://user-images.githubusercontent.com/24855774/59785280-67734980-9292-11e9-93f1-55801f3d2d7c.png)

As a result of using the `author` embed field to produce a smaller icon, the shortcut title/link is now white.